### PR TITLE
Fix size for drawing margin square

### DIFF
--- a/src/commonMain/kotlin/qrcode/raw/QRCodeProcessor.kt
+++ b/src/commonMain/kotlin/qrcode/raw/QRCodeProcessor.kt
@@ -227,7 +227,7 @@ class QRCodeProcessor @JvmOverloads constructor(
                 if (cellData.squareInfo.type != QRCodeSquareType.MARGIN) {
                     graphics.fillRect(x, y, cellSize, cellSize, brightColor)
                 } else {
-                    graphics.fillRect(x, y, cellSize, cellSize, marginColor)
+                    graphics.fillRect(x, y, qrCodeGraphics.dimensions()[0], qrCodeGraphics.dimensions[1], marginColor)
                 }
             }
         }

--- a/src/commonMain/kotlin/qrcode/raw/QRCodeProcessor.kt
+++ b/src/commonMain/kotlin/qrcode/raw/QRCodeProcessor.kt
@@ -227,7 +227,7 @@ class QRCodeProcessor @JvmOverloads constructor(
                 if (cellData.squareInfo.type != QRCodeSquareType.MARGIN) {
                     graphics.fillRect(x, y, cellSize, cellSize, brightColor)
                 } else {
-                    graphics.fillRect(x, y, qrCodeGraphics.dimensions()[0], qrCodeGraphics.dimensions[1], marginColor)
+                    graphics.fillRect(x, y, qrCodeGraphics.dimensions()[0], qrCodeGraphics.dimensions()[1], marginColor)
                 }
             }
         }


### PR DESCRIPTION
Currently in QRCodeProcessor.render() the method renderShaded() is called with a provided renderer function. When this renderer function draws the square for the margin of the QR code, cellSize is used for its width and height. This has the result that the margin appears just as a small square in the upper left corner of the QR code image.

The QR code graphic itself has the correct dimensions (including margins), so on a white background it looks fine, but on a dark background, only the upper left corner of the margin space is colored in white, the rest is transparent, showing the dark background.

The fix replaces the width/height properties cellSize, cellSizes with a call to qrCodeGraphics.dimensions() getting the actual width and height of the graphic, so the margin fills the whole square.

(Alternatively, instead of that computeImageSize(cellSize, margin, rawData) could be used again for these two arguments.)