### PR TITLE
feat: compose canvas render exactly fit requested size

### DIFF
--- a/src/androidMain/kotlin/qrcode/render/extensions/AndroidComposeExtensions.kt
+++ b/src/androidMain/kotlin/qrcode/render/extensions/AndroidComposeExtensions.kt
@@ -4,9 +4,12 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.drawscope.translate
 import qrcode.QRCode
 import qrcode.render.graphics.DrawScopeGraphics
+import kotlin.math.floor
+import kotlin.math.min
 
 /**
  * Extension function to make it easier to draw a [QRCode] into a modern Jetpack Compose [Canvas].
@@ -41,16 +44,30 @@ import qrcode.render.graphics.DrawScopeGraphics
  *
  * @param qrCode The [QRCode] that will be drawn into the [DrawScope].
  * @param offsetTopLeft The [Offset] of the top-left corner where the QRCode will be drawn. Defaults to [Offset.Zero].
- * @param sizeToFitInto The area in which to fit the QRCode. Defaults to the `size` of the [DrawScope].
+ * @param sizeToFitInto The area in which to fit the QRCode. The rendered QRCode is square and sized to the smaller
+ * dimension. The result may be slightly smaller than this size. Defaults to the `size` of the [DrawScope].
+ * @param fitSizeExactly When true, the QRCode will be scaled to fit exactly within the smaller dimension of
+ * [sizeToFitInto]. Defaults to `false`.
  *
  */
 fun DrawScope.drawQRCode(
     qrCode: QRCode,
     offsetTopLeft: Offset = Offset.Zero,
     sizeToFitInto: Size = this.size,
+    fitSizeExactly: Boolean = false,
 ) {
-    val width = sizeToFitInto.width.toInt()
-    val height = sizeToFitInto.height.toInt()
+    val referenceSize = min(sizeToFitInto.width, sizeToFitInto.height)
+
+    val (width, height) = if (fitSizeExactly) {
+        val numberOfSquaresAcross = qrCode.rawData.size
+        val squareSizeThatFits = floor(referenceSize / numberOfSquaresAcross.toDouble()).toInt()
+
+        val nextCanvasSizeThatFits = (squareSizeThatFits + 1) * numberOfSquaresAcross
+
+        Pair(nextCanvasSizeThatFits, nextCanvasSizeThatFits)
+    } else {
+        Pair(sizeToFitInto.width.toInt(), sizeToFitInto.height.toInt())
+    }
 
     qrCode.fitIntoArea(width, height)
 
@@ -61,7 +78,15 @@ fun DrawScope.drawQRCode(
     qrCodeGraphics.drawingInterface = drawScopeGraphics
 
     translate(offsetTopLeft.x, offsetTopLeft.y) {
-        qrCode.render()
+        val scaleFactor = if (fitSizeExactly) {
+            referenceSize / width
+        } else {
+            1f
+        }
+
+        scale(scaleFactor, pivot = Offset.Zero) {
+            qrCode.render()
+        }
     }
 
     qrCodeGraphics.drawingInterface = previousDrawingInterface


### PR DESCRIPTION
Introduces a Jetpack Compose workaround for #197, by adding an optional `fitSizeExactly` parameter to the `DrawScope.drawQRCode` compose extension function.

When enabled, the QR code is rendered with a square size that is 1 pixel larger than is required. Then, it is scaled down so that it fits the requested bounds exactly.

Default behavior is unchanged.